### PR TITLE
fix: align Sonar Plugin API baseline for SonarQube compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [2.0.1] - 2026-06-09
+
+### Changed
+- Lowered the declared Sonar Plugin API baseline (`pluginApiMinVersion`) from `13.5.0.4319` to `11.1.0.2693`, fixing the startup failure on SonarQube Server whose Plugin API was lower than the declared minimum (e.g. `13.0.0.3026`). The minimum now matches the compile-time `sonar-plugin-api` version and is decoupled from it via a dedicated `pluginApiMinVersion` property.
+- Aligned `sonar-plugin-api` to `11.1.0.2693` to match the `dosonarapi-asyncapi` base plugin.
+- Bumped the base plugin dependencies (`asyncapi-front-end`, `asyncapi-test-tools`) to `2.0.1`.
+
+### Removed
+- Removed unused dependencies `jackson-dataformat-yaml`, `com.networknt:json-schema-validator` and `org.json:json`. These were not referenced by any source and bundled two conflicting Jackson lines (2.x and 3.x) into the shaded plugin JAR.
+
+### Fixed
+- Moved `asyncapi-test-tools` to `test` scope (was resolving as `compile`) and dropped the unnecessary `junit-platform-console-standalone` test dependency.
+
 ## [2.0.0] - 2026-05-20
 
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apiaddicts.apitools.dosonarapi</groupId>
   <artifactId>sonarasyncapi-rules-community</artifactId>
-  <version>2.0.0</version>
+  <version>2.0.1</version>
   <packaging>sonar-plugin</packaging>
 
   <name>SonarQube AsyncAPI Community Rules</name>
@@ -47,10 +47,10 @@
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <sonar.version>13.5.0.4319</sonar.version>
-    <sonarasyncapi.version>2.0.0</sonarasyncapi.version>
+    <sonar.version>11.1.0.2693</sonar.version>
+    <pluginApiMinVersion>11.1.0.2693</pluginApiMinVersion>
+    <sonarasyncapi.version>2.0.1</sonarasyncapi.version>
     <sonaranalyzer.version>2.22.0.4796</sonaranalyzer.version>
-    <orgjson.version>20251224</orgjson.version>
     <junit.version>4.13.2</junit.version>
     <assertj.version>3.27.7</assertj.version>
 
@@ -63,13 +63,6 @@
 
 
   <dependencies>
-    <!-- https://mvnrepository.com/artifact/org.junit.platform/junit-platform-console-standalone -->
-    <dependency>
-        <groupId>org.junit.platform</groupId>
-        <artifactId>junit-platform-console-standalone</artifactId>
-        <version>6.0.3</version>
-        <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>org.apiaddicts.apitools.dosonarapi</groupId>
       <artifactId>asyncapi-front-end</artifactId>
@@ -82,25 +75,9 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.dataformat</groupId>
-      <artifactId>jackson-dataformat-yaml</artifactId>
-      <version>2.21.3</version>
-    </dependency>
-    <dependency>
       <groupId>org.sonarsource.analyzer-commons</groupId>
       <artifactId>sonar-analyzer-commons</artifactId>
       <version>${sonaranalyzer.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.networknt</groupId>
-      <artifactId>json-schema-validator</artifactId>
-      <version>3.0.2</version>
-    </dependency>
-    <!-- https://mvnrepository.com/artifact/org.json/json -->
-    <dependency>
-      <groupId>org.json</groupId>
-      <artifactId>json</artifactId>
-      <version>${orgjson.version}</version>
     </dependency>
 
     <!-- test dependencies -->
@@ -108,6 +85,7 @@
       <groupId>org.apiaddicts.apitools.dosonarapi</groupId>
       <artifactId>asyncapi-test-tools</artifactId>
       <version>${sonarasyncapi.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -194,7 +172,7 @@
           <pluginClass>apiquality.sonar.asyncapi.AsyncAPICustomPlugin</pluginClass>
           <skipDependenciesPackaging>true</skipDependenciesPackaging>
           <sonarLintSupported>true</sonarLintSupported>
-          <pluginApiMinVersion>${sonar.version}</pluginApiMinVersion>
+          <pluginApiMinVersion>${pluginApiMinVersion}</pluginApiMinVersion>
           <basePlugin>asyncapi</basePlugin>
         </configuration>
       </plugin>


### PR DESCRIPTION
Lower the declared pluginApiMinVersion from 13.5.0.4319 to 11.1.0.2693 to fix the plugin failing to load on SonarQube whose Plugin API is below the declared minimum. Decouple pluginApiMinVersion from sonar.version and align sonar-plugin-api to 11.1.0.2693 to match the dosonarapi-asyncapi base plugin.

Remove unused dependencies (jackson-dataformat-yaml, networknt json-schema-validator, org.json) that bundled conflicting Jackson 2.x and 3.x lines into the shaded JAR. Move asyncapi-test-tools to test scope and drop the unnecessary junit-platform-console-standalone dependency. Bump base plugin dependencies to 2.0.1.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The plugin declares a Sonar Plugin API minimum of `13.5.0.4319`. On SonarQube instances whose Plugin API is lower than that (e.g. `13.0.0.3026`), the plugin fails to load at startup with:

```
Plugin AsyncAPI Custom [asyncapicustom] requires at least Sonar Plugin API version 13.5.0.4319 (current: 13.0.0.3026)
```

In addition, the build pulls in three unused dependencies (`jackson-dataformat-yaml`, `com.networknt:json-schema-validator`, `org.json:json`) that drag two conflicting Jackson lines (2.x and 3.x) into the shaded plugin JAR, and `asyncapi-test-tools` resolves as `compile` instead of `test`.

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Lowered the declared `pluginApiMinVersion` to `11.1.0.2693` (decoupled from `sonar.version` via a dedicated property) and aligned `sonar-plugin-api` to `11.1.0.2693`, matching the `dosonarapi-asyncapi` base plugin. The plugin now loads on SonarQube with Plugin API ≥ 11.x.
- Removed the unused `jackson-dataformat-yaml`, `com.networknt:json-schema-validator` and `org.json:json` dependencies, eliminating the conflicting Jackson 2.x/3.x bundling and shrinking the shaded JAR.
- Moved `asyncapi-test-tools` to `test` scope and dropped the unnecessary `junit-platform-console-standalone` dependency; bumped base plugin dependencies to `2.0.1`.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Verified with `mvn clean package`: `BUILD SUCCESS`, 215 tests pass (2 skipped). The generated JAR reports `Minimal Sonar Plugin API Version: 11.1.0.2693` and no longer contains the Jackson 3.x / networknt / org.json classes.
